### PR TITLE
Add two new cmake lib -> lib64 string replaces

### DIFF
--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -95,8 +95,8 @@ iconv -f iso8859-1 -t utf-8 AUTHORS.txt > AUTHORS.conv && mv -f AUTHORS.conv AUT
 #multilibs
 %ifarch x86_64 sparc64 ppc64 amd64 s390x
 %{__sed} -i "s|KICAD_PLUGINS lib/kicad/plugins|KICAD_PLUGINS lib64/kicad/plugins|" CMakeLists.txt
-%{__sed} -i "s|KICAD_LIB ${CMAKE_INSTALL_PREFIX}/lib|KICAD_LIB ${CMAKE_INSTALL_PREFIX}/lib64|" CMakeLists.txt
-%{__sed} -i "s|KICAD_USER_PLUGIN ${CMAKE_INSTALL_PREFIX}/lib/kicad/plugins|KICAD_USER_PLUGIN ${CMAKE_INSTALL_PREFIX}/lib64/kicad/plugins|" CMakeLists.txt
+%{__sed} -i "s|KICAD_LIB \${CMAKE_INSTALL_PREFIX}/lib|KICAD_LIB \${CMAKE_INSTALL_PREFIX}/lib64|" CMakeLists.txt
+%{__sed} -i "s|KICAD_USER_PLUGIN \${CMAKE_INSTALL_PREFIX}/lib/kicad/plugins|KICAD_USER_PLUGIN \${CMAKE_INSTALL_PREFIX}/lib64/kicad/plugins|" CMakeLists.txt
 #%{__sed} -i "s|/usr/lib/kicad|/usr/lib64/kicad|" %{SOURCE3}
 %endif
 

--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -95,6 +95,8 @@ iconv -f iso8859-1 -t utf-8 AUTHORS.txt > AUTHORS.conv && mv -f AUTHORS.conv AUT
 #multilibs
 %ifarch x86_64 sparc64 ppc64 amd64 s390x
 %{__sed} -i "s|KICAD_PLUGINS lib/kicad/plugins|KICAD_PLUGINS lib64/kicad/plugins|" CMakeLists.txt
+%{__sed} -i "s|KICAD_LIB ${CMAKE_INSTALL_PREFIX}/lib|KICAD_LIB ${CMAKE_INSTALL_PREFIX}/lib64|" CMakeLists.txt
+%{__sed} -i "s|KICAD_USER_PLUGIN ${CMAKE_INSTALL_PREFIX}/lib/kicad/plugins|KICAD_USER_PLUGIN ${CMAKE_INSTALL_PREFIX}/lib64/kicad/plugins|" CMakeLists.txt
 #%{__sed} -i "s|/usr/lib/kicad|/usr/lib64/kicad|" %{SOURCE3}
 %endif
 

--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -239,6 +239,7 @@ update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
 %{_bindir}/*
 %{_prefix}/lib/python2.7/site-packages/*
 %{_libdir}/%{name}
+%{_libdir}/libkicad_3dsg.so*
 %{_datadir}/%{name}/
 %{_datadir}/applications/*.desktop
 %{_datadir}/icons/hicolor/*/mimetypes/application-x-*.*


### PR DESCRIPTION
When Cirilo added the 3d viewer plugins two new cmake variables were created referencing the lib/ directory. Because these weren't being changed the plugins weren't being moved in to the package and caused errors. Hopefully this should fix that.

Maybe a longer term solution would be to use LIB_INSTALL_DIR.
