### PR TITLE
Add footprint libraries

### DIFF
--- a/kicad-clone.sh
+++ b/kicad-clone.sh
@@ -28,6 +28,15 @@ else
     git clone https://github.com/KiCad/kicad-i18n.git
 fi
 
+if [ -d kicad-footprints ]; then
+    cd kicad-footprints
+    git fetch origin
+    git reset --hard origin/master
+    cd ..
+else
+    git clone https://github.com/KiCad/kicad-footprints.git
+fi
+
 #TODO(mangelajo): pull the new doc builds
 #if [ -d kicad-doc.bzr ]; then
 #	cd kicad-doc.bzr
@@ -36,17 +45,3 @@ fi
 #else
 #	bzr branch --stacked lp:~kicad-developers/kicad/doc kicad-doc.bzr
 #fi
-
-
-exit 0
-
-sed -n 's|.*\${KIGITHUB}/\([^)]*\)).*|\1|p'  kicad-library.bzr/template/fp-lib-table.for-github > footprint.list
-
-mkdir -p footprints
-cat footprint.list |while read FP
-	do
-		git clone https://github.com/KiCad/$FP footprints/$FP ||
-			print "$FP missing, possibly gone from GitHub now"
-	done
-
-

--- a/kicad-export.sh
+++ b/kicad-export.sh
@@ -30,6 +30,10 @@ cd ../kicad-i18n
 echo "Creating kicad-i18n-$TIMESTAMP.tar.gz ..."
 git archive --format=tar.gz --prefix=kicad-i18n-$TIMESTAMP/ HEAD > ../kicad-i18n-$TIMESTAMP.tar.gz
 
+cd ../kicad-footprints
+echo "Creating kicad-footprints-$TIMESTAMP.tar.gz ..."
+git archive --format=tar.gz --prefix=kicad-footprints-$TIMESTAMP/ HEAD > ../kicad-footprints-$TIMESTAMP.tar.gz
+
 #TODO(mangelajo): new docs?
 #cd ../kicad-doc.bzr
 #rm -rf kicad-doc-$TIMESTAMP
@@ -38,35 +42,3 @@ git archive --format=tar.gz --prefix=kicad-i18n-$TIMESTAMP/ HEAD > ../kicad-i18n
 #tar cJf ../kicad-doc-$TIMESTAMP.tar.xz kicad-doc-$TIMESTAMP
 #rm -rf kicad-doc-$TIMESTAMP
 #cd ..
-
-exit 0
-
-
-cd footprints
-echo "Creating kicad-footprints-$TIMESTAMP.tar.xz ..."
-rm -rf kicad-footprints-$TIMESTAMP
-mkdir -p kicad-footprints-$TIMESTAMP
->kicad-footprints-$TIMESTAMP/VERSIONS.footprints
-sed -n 's|.*\${KIGITHUB}/\([^)]*\)).*|\1|p' \
-	../kicad-library.bzr/kicad-libraries-$TIMESTAMP/template/fp-lib-table.for-github |
-	while read FP
-	do
-		if [ -d $FP ]
-		then
-			cd $FP
-			REV=$(git rev-list -n 1 --before="$TIMESTAMP" master)
-			if [ -z $REV ]
-			then
-				echo "$FP did not exist at $TIMESTAMP!"
-				REV=$(git rev-list -n 1 master)
-			fi
-			git archive --prefix=$FP/ $REV |tar xf - -C ../kicad-footprints-$TIMESTAMP
-			echo $FP $REV >>../kicad-footprints-$TIMESTAMP/VERSIONS.footprints
-			cd ..
-		else
-			echo "$FP missing now. Update libraries snapshot or patch it away from fp-lib-table!"
-		fi
-	done
-tar -cJf kicad-footprints-$TIMESTAMP.tar.xz kicad-footprints-$TIMESTAMP
-rm -rf kicad-footprints-$TIMESTAMP
-cd ..

--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -29,7 +29,7 @@ Source:         %{name}-%{version}.tar.gz
 #Source: https://github.com/KiCad/kicad-source-mirror/archive/%{commit}/kicad-source-mirror-%{commit}.tar.gz
 Source1:        %{name}-i18n-%{version}.tar.gz
 Source2:        %{name}-libraries-%{version}.tar.gz
-#Source3:        %{name}-footprints-%{version}.tar.xz
+Source3:        %{name}-footprints-%{version}.tar.gz
 #Source7:        Epcos-MKT-1.0.tar.bz2
 #Source8:        %{name}-walter-libraries-%{version}.tar.xz
 #disabled, breaks in devel version
@@ -86,7 +86,7 @@ Kicad est un ensemble de quatres logiciels et un gestionnaire de projet :
 
 
 %prep
-%setup -q -a 1 -a 2
+%setup -q -a 1 -a 2 -a 3
 
 #%patch1 -p1
 
@@ -128,6 +128,13 @@ pushd %{name}-libraries-%{version}/
 %{__make} -j3 VERBOSE=1
 popd
 
+#
+# Footprint libraries
+#
+pushd %{name}-footprints-%{version}/
+%cmake
+%{__make} %{?_smp_mflags} VERBOSE=1
+popd
 
 #
 # Core components
@@ -202,11 +209,12 @@ popd
 install -d %{buildroot}%{_datadir}/%{name}/template
 install -m 644 template/%{name}.pro %{buildroot}%{_datadir}/%{name}/template
 
-# Footprints
-#pushd %{name}-footprints-%{version}/
-#cp -a */ %{buildroot}%{_datadir}/%{name}/modules
-#popd
-#ln -f %{buildroot}%{_datadir}/%{name}/template/fp-lib-table{.for-pretty,}
+#
+# Footprint libraries
+#
+pushd %{name}-footprints-%{version}/
+%make_install
+popd
 
 # Preparing for documentation pull-ups
 #%{__rm} -f  %{name}-doc-%{version}/doc/help/CMakeLists.txt


### PR DESCRIPTION
The nightly builds from KiCad's Copr repository currently do not include any footprints. Unless there is a good reason for this I would propose to include all footprints from the new [kicad-footprints](https://github.com/KiCad/kicad-footprints) repository.

This change should be fairly safe, as current users of the nightlies do not rely on footprints being packaged as part of the KiCad RPM. The logical next step would be to also package the new 3D packages, templates and symbols, but this is more risky because of the incompatibility to the currently used [kicad-library](https://github.com/KiCad/kicad-library) repo.

In the long run, having separate packages for symbols, footprints, templates, 3D packages and documentation (similar to what has been [proposed for Debian](https://wiki.debian.org/KiCad)) is the way to go. But I don't know what the KiCad upstream maintainers plans are, and the nightly builds should be kept in sync with upstream to simplify switching between repositories.