### PR TITLE
Add documentation

### DIFF
--- a/kicad-clone.sh
+++ b/kicad-clone.sh
@@ -55,11 +55,11 @@ else
 	git clone https://github.com/KiCad/kicad-i18n.git
 fi
 
-#TODO(mangelajo): pull the new doc builds
-#if [ -d kicad-doc.bzr ]; then
-#	cd kicad-doc.bzr
-#	bzr update 
-#	cd ..
-#else
-#	bzr branch --stacked lp:~kicad-developers/kicad/doc kicad-doc.bzr
-#fi
+if [ -d kicad-doc ]; then
+	cd kicad-doc
+	git fetch origin
+	git reset --hard origin/master
+	cd ..
+else
+	git clone https://github.com/KiCad/kicad-doc.git
+fi

--- a/kicad-export.sh
+++ b/kicad-export.sh
@@ -41,11 +41,6 @@ cd ../kicad-i18n
 echo "Creating kicad-i18n-$TIMESTAMP.tar.gz ..."
 git archive --format=tar.gz --prefix=kicad-i18n-$TIMESTAMP/ HEAD > ../kicad-i18n-$TIMESTAMP.tar.gz
 
-#TODO(mangelajo): new docs?
-#cd ../kicad-doc.bzr
-#rm -rf kicad-doc-$TIMESTAMP
-#bzr export kicad-doc-$TIMESTAMP
-#echo "Creating kicad-doc-$TIMESTAMP.tar.xz ..."
-#tar cJf ../kicad-doc-$TIMESTAMP.tar.xz kicad-doc-$TIMESTAMP
-#rm -rf kicad-doc-$TIMESTAMP
-#cd ..
+cd ../kicad-doc
+echo "Creating kicad-doc-$TIMESTAMP.tar.gz ..."
+git archive --format=tar.gz --prefix=kicad-doc-$TIMESTAMP/ HEAD > ../kicad-doc-$TIMESTAMP.tar.gz

--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -19,6 +19,7 @@ Source2:        %{name}-templates-%{version}.tar.gz
 Source3:        %{name}-symbols-%{version}.tar.gz
 Source4:        %{name}-footprints-%{version}.tar.gz
 Source5:        %{name}-packages3D-%{version}.tar.gz
+Source6:        %{name}-doc-%{version}.tar.gz
 
 #disabled, breaks in devel version
 #Patch1:         kicad-4.0.0-nostrip.patch
@@ -41,6 +42,9 @@ BuildRequires:  gettext
 BuildRequires:  glm-devel
 BuildRequires:  libcurl-devel
 BuildRequires:  libappstream-glib
+BuildRequires:  asciidoc
+BuildRequires:  dblatex
+BuildRequires:  po4a
 
 Requires:       electronics-menu
 #Requires:       wxPython
@@ -59,10 +63,18 @@ Kicad is a set of four softwares and a project manager:
 - Cvpcb: footprint selector for components used in the circuit design
 - Gerbview: GERBER viewer (photoplotter documents)
 
+%package doc
+Summary:        Documentation for KiCad
+License:        GPLv3+
+BuildArch:      noarch
+
+%description doc
+Documentation for KiCad.
+
 
 %prep
 
-%setup -q -a 1 -a 2 -a 3 -a 4 -a 5
+%setup -q -a 1 -a 2 -a 3 -a 4 -a 5 -a 6
 #%patch1 -p1
 
 
@@ -129,6 +141,15 @@ pushd %{name}-packages3D-%{version}/
 %make_build VERBOSE=1
 popd
 
+# Documentation (HTML only)
+mkdir %{name}-doc-%{version}/build
+pushd %{name}-doc-%{version}/build
+%cmake \
+    -DBUILD_FORMATS=html \
+    ..
+%make_build
+popd
+
 
 %install
 
@@ -170,13 +191,10 @@ pushd %{name}-packages3D-%{version}/
 %make_install
 popd
 
-# Preparing for documentation pull-ups
-#%{__rm} -f  %{name}-doc-%{version}/doc/help/CMakeLists.txt
-#%{__rm} -f  %{name}-doc-%{version}/doc/help/makefile
-#%{__rm} -f  %{name}-doc-%{version}/doc/tutorials/CMakeLists.txt
-#
-#%{__cp} -pr %{name}-doc-%{version}/doc/* %{buildroot}%{_docdir}/%{name}
-#%{__cp} -pr AUTHORS.txt CHANGELOG* %{buildroot}%{_docdir}/%{name}
+# Documentation
+pushd %{name}-doc-%{version}/build
+%make_install
+popd
 
 %find_lang %{name}
 
@@ -219,12 +237,12 @@ update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
 %{_datadir}/mime/packages/*.xml
 %{_datadir}/appdata/*.xml
 #%config(noreplace) %{_sysconfdir}/ld.so.conf.d/kicad.conf
-#%dir %{_docdir}/%{name}/
+
+%files doc
 %{_docdir}/%{name}/*.txt
-%dir %{_docdir}/%{name}/scripts/
+%{_docdir}/%{name}/help/*
 %{_docdir}/%{name}/scripts/*
-#%dir %{_docdir}/%{name}/scripts/bom-in-python/
-#%{_docdir}/%{name}/scripts/bom-in-python/*
+%license %{name}-doc-%{version}/LICENSE.adoc
 
 
 %changelog


### PR DESCRIPTION
This adds the documentation from the kicad-doc repository as a separate subpackage kicad-doc to the nightly builds. The approach I chose is practically identical to how the documentation for 4.0.7 is packaged in Fedora right now, which means it should be fairly safe (i.e. not cause any issues for users switching between stable and nightly builds).

Only the HTML variant is built and installed. PDF and EPUB require a more complex build environment and would significantly increase build time. If someone absolutely wants to include other file formats in the nightlies then it can easily be added later on.