### PR TITLE
Fix Copr build of kicad-doc on Fedora 26

### DIFF
--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -45,6 +45,7 @@ BuildRequires:  libappstream-glib
 BuildRequires:  asciidoc
 BuildRequires:  dblatex
 BuildRequires:  po4a
+BuildRequires:  perl(Unicode::GCString)
 
 Requires:       electronics-menu
 #Requires:       wxPython


### PR DESCRIPTION
I just saw that the last Copr build [723372](https://copr.fedorainfracloud.org/coprs/g/kicad/kicad/build/723372/) failed on Fedora 26 due to a missing dependency. According to the log file, the Unicode::GCString module is not available.

I did not actually test this change locally (don't have a Fedora 26 installation available), but this is backported from the upstream SPEC and should (hopefully) not cause any further issues.