### PR TITLE
Fix displayed copr status path.

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -196,8 +196,9 @@ fi
 # Do a remote copr build.
 if [ -n "${COPR_ID}" ]; then
 	set +x
+	STATUS_LOCATION=$(echo ${COPR_ID} | sed -e 's/@/g\//')
 	echo "Starting the remote copr build.  Check the status of the build here:"
-	echo "https://copr.fedoraproject.org/coprs/${COPR_ID}/builds/"
+	echo "https://copr.fedoraproject.org/coprs/${STATUS_LOCATION}/builds/"
 	set -x
 	copr-cli build "${COPR_ID}" "${SRPM}"
 fi


### PR DESCRIPTION
I figure I might as well correct this now, to avoid future confusion.  Please pull from my fix_echo_message branch to correct the status message for IDs with a leading '@'.

I tested this, and it displayed the correct message, but naturally it didn't allow me to actually make a copr build in @kicad. :-)