### PR TITLE
Handle tags without embedded dashes.

### DIFF
--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -1,11 +1,11 @@
-%global version_suffix @VERSION_SUFFIX@
+%global full_version @FULL_VERSION@
 
 Name:           kicad
 Version:        @VERSION@
 # Higher epoch than stable builds to make sure your nightly builds are prioritized
 # if you enabled the nightly build repo
 Epoch:          @EPOCH@
-Release:        %{version_suffix}%{?dist}
+Release:        @RELEASE@%{?dist}
 Summary:        Electronic schematic diagrams and printed circuit board artwork
 
 License:        GPLv2+
@@ -15,13 +15,13 @@ URL:            http://www.kicad-pcb.org
 #   kicad-clone.sh ... clone BZR repositories of main, libraries, doc
 #   kicad-update.sh ... update BZR repositories
 #   kicad-export.sh ... export BZR repositories and create tarballs
-Source:         %{name}-%{version}-%{version_suffix}.tar.gz
-Source1:        %{name}-i18n-%{version}-%{version_suffix}.tar.gz
-Source2:        %{name}-templates-%{version}-%{version_suffix}.tar.gz
-Source3:        %{name}-symbols-%{version}-%{version_suffix}.tar.gz
-Source4:        %{name}-footprints-%{version}-%{version_suffix}.tar.gz
-Source5:        %{name}-packages3D-%{version}-%{version_suffix}.tar.gz
-Source6:        %{name}-doc-%{version}-%{version_suffix}.tar.gz
+Source:         %{name}-%{full_version}.tar.gz
+Source1:        %{name}-i18n-%{full_version}.tar.gz
+Source2:        %{name}-templates-%{full_version}.tar.gz
+Source3:        %{name}-symbols-%{full_version}.tar.gz
+Source4:        %{name}-footprints-%{full_version}.tar.gz
+Source5:        %{name}-packages3D-%{full_version}.tar.gz
+Source6:        %{name}-doc-%{full_version}.tar.gz
 
 #disabled, breaks in devel version
 #Patch1:         kicad-4.0.0-nostrip.patch
@@ -77,7 +77,7 @@ Documentation for KiCad.
 
 %prep
 
-%setup -q -n %{name}-%{version}-%{version_suffix} -a 1 -a 2 -a 3 -a 4 -a 5 -a 6
+%setup -q -n %{name}-%{full_version} -a 1 -a 2 -a 3 -a 4 -a 5 -a 6
 #%patch1 -p1
 
 
@@ -112,8 +112,8 @@ Documentation for KiCad.
 %make_build VERBOSE=1
 
 # Localization
-mkdir %{name}-i18n-%{version}-%{version_suffix}/build
-pushd %{name}-i18n-%{version}-%{version_suffix}/build
+mkdir %{name}-i18n-%{full_version}/build
+pushd %{name}-i18n-%{full_version}/build
 %cmake \
     -DKICAD_I18N_UNIX_STRICT_PATH=ON \
     ..
@@ -121,32 +121,32 @@ pushd %{name}-i18n-%{version}-%{version_suffix}/build
 popd
 
 # Templates
-pushd %{name}-templates-%{version}-%{version_suffix}/
+pushd %{name}-templates-%{full_version}/
 %cmake .
 %make_build VERBOSE=1
 popd
 
 # Symbol libraries
-pushd %{name}-symbols-%{version}-%{version_suffix}/
+pushd %{name}-symbols-%{full_version}/
 %cmake .
 %make_build VERBOSE=1
 popd
 
 # Footprint libraries
-pushd %{name}-footprints-%{version}-%{version_suffix}/
+pushd %{name}-footprints-%{full_version}/
 %cmake .
 %make_build VERBOSE=1
 popd
 
 # 3D models
-pushd %{name}-packages3D-%{version}-%{version_suffix}/
+pushd %{name}-packages3D-%{full_version}/
 %cmake .
 %make_build VERBOSE=1
 popd
 
 # Documentation (HTML only)
-mkdir %{name}-doc-%{version}-%{version_suffix}/build
-pushd %{name}-doc-%{version}-%{version_suffix}/build
+mkdir %{name}-doc-%{full_version}/build
+pushd %{name}-doc-%{full_version}/build
 %cmake \
     -DBUILD_FORMATS=html \
     ..
@@ -161,7 +161,7 @@ popd
 %{__cp} -p AUTHORS.txt %{buildroot}%{_docdir}/%{name}
 
 # Localization
-pushd %{name}-i18n-%{version}-%{version_suffix}/build
+pushd %{name}-i18n-%{full_version}/build
 %make_install
 popd
 
@@ -175,27 +175,27 @@ for desktopfile in %{buildroot}%{_datadir}/applications/*.desktop ; do
 done
 
 # Templates
-pushd %{name}-templates-%{version}-%{version_suffix}/
+pushd %{name}-templates-%{full_version}/
 %make_install
 popd
 
 # Symbol libraries
-pushd %{name}-symbols-%{version}-%{version_suffix}/
+pushd %{name}-symbols-%{full_version}/
 %make_install
 popd
 
 # Footprint libraries
-pushd %{name}-footprints-%{version}-%{version_suffix}/
+pushd %{name}-footprints-%{full_version}/
 %make_install
 popd
 
 # 3D models
-pushd %{name}-packages3D-%{version}-%{version_suffix}/
+pushd %{name}-packages3D-%{full_version}/
 %make_install
 popd
 
 # Documentation
-pushd %{name}-doc-%{version}-%{version_suffix}/build
+pushd %{name}-doc-%{full_version}/build
 %make_install
 popd
 
@@ -245,7 +245,7 @@ update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
 %{_docdir}/%{name}/*.txt
 %{_docdir}/%{name}/help/*
 %{_docdir}/%{name}/scripts/*
-%license %{name}-doc-%{version}-%{version_suffix}/LICENSE.adoc
+%license %{name}-doc-%{full_version}/LICENSE.adoc
 
 
 %changelog


### PR DESCRIPTION
The builder.sh script cannot handle tags like 5.0.0 because it attempts
to split the tag on a "-" character.

I've updated the script and spec file to handle all three cases: no tag, tag with an -rc suffix, and tag without a suffix.  This also gave me the opportunity to make the spec file more readable, by eliminating all the version_suffix macros.

There are no changes to the number of packages generated, or the resulting package names.

There is a new flag to the builder script (-r release) which is only used in the case of building a tagged release without an -rc suffix.  Fedora requires (or at least strongly suggests) that the release be set to "1" for the first release of a package, and that any later patches to the upstream be handled by incrementing the release number.  This flag allows one to specify that.

None of these changes will have any effect on the nightlies, nor will the changes require any different flags to the builder script.