### PR TITLE
Restrict architectures and remove boost dependency

### DIFF
--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -20,6 +20,9 @@ Source4:        %{name}-footprints-%{full_version}.tar.gz
 Source5:        %{name}-packages3D-%{full_version}.tar.gz
 Source6:        %{name}-doc-%{full_version}.tar.gz
 
+# https://bugs.launchpad.net/kicad/+bug/1755752
+ExclusiveArch: %{ix86} x86_64 %{arm} aarch64
+
 BuildRequires:  cmake
 BuildRequires:  doxygen
 BuildRequires:  desktop-file-utils

--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -47,7 +47,6 @@ BuildRequires:  dblatex
 BuildRequires:  po4a
 BuildRequires:  perl(Unicode::GCString)
 
-Requires:       boost
 Requires:       electronics-menu
 
 %description


### PR DESCRIPTION
The first commit adds an ExclusiveArch tag to the SPEC file. KiCad only supports x86, x86_64, arm and arm64 (as was recently brought up by the Debian maintainer and discussed on the mailing list and bug tracker).

The second commit removes the boost runtime dependency. KiCad depends on boost, but it is only used at compile time.