### PR TITLE
Prepare SPEC file for Fedora 29

### DIFF
--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -26,6 +26,7 @@ ExclusiveArch: %{ix86} x86_64 %{arm} aarch64
 BuildRequires:  cmake
 BuildRequires:  doxygen
 BuildRequires:  desktop-file-utils
+BuildRequires:  gcc-c++
 BuildRequires:  gettext
 BuildRequires:  git
 BuildRequires:  libappstream-glib

--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -221,8 +221,8 @@ update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
 
 %files -f %{name}.lang
 %{_bindir}/*
-%{_libdir}/%{name}/*
 %{_libdir}/libkicad_3dsg.so*
+%{_libdir}/%{name}/plugins/*
 %{python2_sitelib}/*
 %{_datadir}/%{name}/*
 %{_datadir}/appdata/*.xml


### PR DESCRIPTION
The first commit is just a small improvement to the %files section, the second commit adds gcc-c++ as a build-time dependency (required for Fedora 29).