### PR TITLE
Remove scriptlets

### DIFF
--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -200,7 +200,6 @@ appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/appdata/*.appdata
 
 %post
 touch --no-create %{_datadir}/icons/hicolor || :
-touch --no-create %{_datadir}/mime/packages &> /dev/null || :
 update-desktop-database &> /dev/null || :
 
 
@@ -209,15 +208,12 @@ if [ $1 -eq 0 ]
 then
     touch --no-create %{_datadir}/icons/hicolor || :
     gtk-update-icon-cache --quiet %{_datadir}/icons/hicolor || :
-    touch --no-create %{_datadir}/mime/packages &> /dev/null || :
-    update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
 fi
 update-desktop-database %{_datadir}/applications > /dev/null 2>&1 || :
 
 
 %posttrans
 gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
-update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
 
 
 %files -f %{name}.lang

--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -198,22 +198,6 @@ popd
 appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/appdata/*.appdata.xml
 
 
-%post
-touch --no-create %{_datadir}/icons/hicolor || :
-
-
-%postun
-if [ $1 -eq 0 ]
-then
-    touch --no-create %{_datadir}/icons/hicolor || :
-    gtk-update-icon-cache --quiet %{_datadir}/icons/hicolor || :
-fi
-
-
-%posttrans
-gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
-
-
 %files -f %{name}.lang
 %{_bindir}/*
 %{_libdir}/libkicad_3dsg.so*

--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -200,7 +200,6 @@ appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/appdata/*.appdata
 
 %post
 touch --no-create %{_datadir}/icons/hicolor || :
-update-desktop-database &> /dev/null || :
 
 
 %postun
@@ -209,7 +208,6 @@ then
     touch --no-create %{_datadir}/icons/hicolor || :
     gtk-update-icon-cache --quiet %{_datadir}/icons/hicolor || :
 fi
-update-desktop-database %{_datadir}/applications > /dev/null 2>&1 || :
 
 
 %posttrans


### PR DESCRIPTION
Even after all the cleanup we have done in the last months, the SPEC file still includes some old and now obsolete constructs. These commits remove the %post, %postun and %posttrans sections, as none of the scriptlets is required anymore:
- *mimeinfo* is deprecated since Fedora 24
  - https://fedoraproject.org/w/index.php?title=Packaging:Scriptlets&oldid=494555#mimeinfo
  - https://pagure.io/packaging-committee/issue/636
- *desktop-database* is deprecated since Fedora 25
  - https://fedoraproject.org/w/index.php?title=Packaging:Scriptlets&oldid=494574#desktop-database
- *icon cache* has been deprecated last year and is currently being removed from all upstream packages
  - https://pagure.io/packaging-committee/issue/736