### PR TITLE
Update build-time dependencies and remove remainders of wxPython support

### DIFF
--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -24,15 +24,14 @@ Source6:        %{name}-doc-%{full_version}.tar.gz
 ExclusiveArch: %{ix86} x86_64 %{arm} aarch64
 
 BuildRequires:  cmake
-BuildRequires:  doxygen
 BuildRequires:  desktop-file-utils
+BuildRequires:  doxygen
 BuildRequires:  gcc-c++
 BuildRequires:  gettext
 BuildRequires:  git
 BuildRequires:  libappstream-glib
 BuildRequires:  swig
 BuildRequires:  boost-devel
-BuildRequires:  bzip2-devel
 BuildRequires:  compat-wxGTK3-gtk2-devel
 BuildRequires:  glew-devel
 BuildRequires:  glm-devel
@@ -40,8 +39,9 @@ BuildRequires:  libcurl-devel
 BuildRequires:  OCE-devel
 BuildRequires:  openssl-devel
 BuildRequires:  python2-devel
+
+# Documentation
 BuildRequires:  asciidoc
-BuildRequires:  dblatex
 BuildRequires:  po4a
 BuildRequires:  perl(Unicode::GCString)
 

--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -40,9 +40,6 @@ BuildRequires:  libcurl-devel
 BuildRequires:  OCE-devel
 BuildRequires:  openssl-devel
 BuildRequires:  python2-devel
-#BuildRequires:  wxPython-devel
-#BuildRequires:  compat-wxPython3-gtk2
-#BuildRequires:  compat-wxPython3-gtk2-devel
 BuildRequires:  asciidoc
 BuildRequires:  dblatex
 BuildRequires:  po4a
@@ -98,9 +95,6 @@ Documentation for KiCad.
     -DCMAKE_BUILD_TYPE=@BUILD_TYPE@ \
     -DwxWidgets_CONFIG_EXECUTABLE=%{_bindir}/%{wx_config} \
     .
-# workaround to get WXPYTHON_VERSION set in config.h
-%{__make} rebuild_cache
-# end workaround
 %make_build VERBOSE=1
 
 # Localization


### PR DESCRIPTION
As wxPython support is currently broken, I suggest to remove all traces of the previous effort to bring it back with the help of the (now obsolete) GTK2 compatibility package. It can be re-enabled as soon as the port of KiCad to GTK3 is finished. This is one of the goals for KiCad 5.1.

The second patch updates the build-time dependencies. The removal of dblatex (based on https://github.com/KiCad/kicad-doc/pull/612) should speed up the build process significantly.

As a side effect, these changes make the nightly SPEC more similar to the [upstream SPEC](https://src.fedoraproject.org/rpms/kicad/blob/master/f/kicad.spec).