### PR TITLE
Move 3D models into separate package

### DIFF
--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -56,6 +56,15 @@ following software tools: KiCad (project manager), Eeschema (schematic editor
 and component editor), Pcbnew (circuit board layout editor and footprint
 editor) and GerbView (Gerber viewer).
 
+%package packages3d
+Summary:        3D models for KiCad
+License:        CC-BY-SA
+BuildArch:      noarch
+Requires:       kicad
+
+%description packages3d
+3D models for KiCad.
+
 %package doc
 Summary:        Documentation for KiCad
 License:        GPLv3+
@@ -197,12 +206,17 @@ appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/appdata/*.appdata
 %{_libdir}/libkicad_3dsg.so*
 %{_libdir}/%{name}/plugins/*
 %{python2_sitelib}/*
+%exclude %{_datadir}/%{name}/modules/packages3d/*
 %{_datadir}/%{name}/*
 %{_datadir}/appdata/*.xml
 %{_datadir}/applications/*.desktop
 %{_datadir}/icons/hicolor/*/mimetypes/application-x-*.*
 %{_datadir}/icons/hicolor/*/apps/*.*
 %{_datadir}/mime/packages/*.xml
+
+%files packages3d
+%{_datadir}/%{name}/modules/packages3d/*.3dshapes
+%license %{name}-packages3D-%{full_version}/LICENSE.md
 
 %files doc
 %{_docdir}/%{name}/*.txt


### PR DESCRIPTION
Now that @stevefalco has split the 3D models from the Fedora upstream package [1], I suggest to do the same for the nightlies. Our users should not be forced to install the 3D models, as they occupy a lot of disk space and have to be re-downloaded as part of every new build.

We could also introduce a separate SPEC file for the 3D models, similar to what I'm doing in my kicad-nightly copr [2]. This would improve the user experience even more, as an updated package could be provided selectively only when the files were changed since the last build.

This closes issue #7 and [lp:1784162](https://bugs.launchpad.net/kicad/+bug/1784162). Further refactoring depends on the upstream maintainers, as I would like to keep the packaging of the nightly builds in sync to the upstream packaging.

[1] https://src.fedoraproject.org/rpms/kicad/c/c63ced1b285a30ef91a2e1973aebe6de173ed3d7?branch=master
[2] https://github.com/aimylios/fedora-kicad-packaging/tree/develop