### PR TITLE
More SPEC file cleanup and fix directory ownership

### DIFF
--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -202,11 +202,11 @@ appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/appdata/*.appdata
 
 %files -f %{name}.lang
 %{_bindir}/*
+%{_libdir}/%{name}/
 %{_libdir}/libkicad_3dsg.so*
-%{_libdir}/%{name}/plugins/*
 %{python2_sitelib}/*
+%{_datadir}/%{name}/
 %exclude %{_datadir}/%{name}/modules/packages3d/*
-%{_datadir}/%{name}/*
 %{_datadir}/appdata/*.xml
 %{_datadir}/applications/*.desktop
 %{_datadir}/icons/hicolor/*/mimetypes/application-x-*.*
@@ -214,13 +214,11 @@ appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/appdata/*.appdata
 %{_datadir}/mime/packages/*.xml
 
 %files packages3d
-%{_datadir}/%{name}/modules/packages3d/*.3dshapes
+%{_datadir}/%{name}/modules/packages3d/*.3dshapes/
 %license %{name}-packages3D-%{full_version}/LICENSE.md
 
 %files doc
-%{_docdir}/%{name}/*.txt
-%{_docdir}/%{name}/help/*
-%{_docdir}/%{name}/scripts/*
+%{_docdir}/%{name}/
 %license %{name}-doc-%{full_version}/LICENSE.adoc
 
 

--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -43,7 +43,6 @@ BuildRequires:  python2-devel
 # Documentation
 BuildRequires:  asciidoc
 BuildRequires:  po4a
-BuildRequires:  perl(Unicode::GCString)
 
 Requires:       electronics-menu
 

--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -103,7 +103,7 @@ Documentation for KiCad.
     -DCMAKE_BUILD_TYPE=@BUILD_TYPE@ \
     -DwxWidgets_CONFIG_EXECUTABLE=%{_bindir}/%{wx_config} \
     .
-%make_build VERBOSE=1
+%make_build
 
 # Localization
 mkdir %{name}-i18n-%{full_version}/build/
@@ -111,31 +111,31 @@ pushd %{name}-i18n-%{full_version}/build/
 %cmake \
     -DKICAD_I18N_UNIX_STRICT_PATH=ON \
     ..
-%make_build VERBOSE=1
+%make_build
 popd
 
 # Templates
 pushd %{name}-templates-%{full_version}/
 %cmake .
-%make_build VERBOSE=1
+%make_build
 popd
 
 # Symbol libraries
 pushd %{name}-symbols-%{full_version}/
 %cmake .
-%make_build VERBOSE=1
+%make_build
 popd
 
 # Footprint libraries
 pushd %{name}-footprints-%{full_version}/
 %cmake .
-%make_build VERBOSE=1
+%make_build
 popd
 
 # 3D models
 pushd %{name}-packages3D-%{full_version}/
 %cmake .
-%make_build VERBOSE=1
+%make_build
 popd
 
 # Documentation (HTML only)


### PR DESCRIPTION
The first commit removes a dependency that was only required by Fedora 26, the second commit fixes a problem with unowned directories (that would not be removed upon de-installation) and the last one is purely cosmetic to further align our SPEC file with the one used by Fedora upstream.