### PR TITLE
Handle ambiguous Python shebang

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -125,6 +125,9 @@ done
 rm -fr build/rpmbuild
 mkdir -p build/rpmbuild/{SPECS,SOURCES}
 
+# Copy all patches to the SOURCES directory.
+cp *.patch build/rpmbuild/SOURCES/
+
 # Get/update the source repos.
 get_one "kicad"			"https://git.launchpad.net"	"${TAG}"
 get_one "kicad-i18n"		"https://github.com/KiCad"	"${TAG}"

--- a/kicad-fix-python-shebang.patch
+++ b/kicad-fix-python-shebang.patch
@@ -1,0 +1,10 @@
+diff --git a/pcbnew/python/plugins/touch_slider_wizard.py b/pcbnew/python/plugins/touch_slider_wizard.py
+index e0086e427..70924511f 100644
+--- a/pcbnew/python/plugins/touch_slider_wizard.py
++++ b/pcbnew/python/plugins/touch_slider_wizard.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/python2
+ 
+ #
+ # This program source code file is part of KiCad, a free EDA CAD application.

--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -20,6 +20,8 @@ Source4:        %{name}-footprints-%{full_version}.tar.gz
 Source5:        %{name}-packages3D-%{full_version}.tar.gz
 Source6:        %{name}-doc-%{full_version}.tar.gz
 
+Patch1:         kicad-fix-python-shebang.patch
+
 # https://bugs.launchpad.net/kicad/+bug/1755752
 ExclusiveArch: %{ix86} x86_64 %{arm} aarch64
 
@@ -76,6 +78,7 @@ Documentation for KiCad.
 %prep
 
 %setup -q -n %{name}-%{full_version} -a 1 -a 2 -a 3 -a 4 -a 5 -a 6
+%patch1 -p1
 
 
 %build


### PR DESCRIPTION
Python 2.7 will reach its EOL during the lifetime of the upcoming Fedora 30 (current rawhide). The next Fedora release integrates a couple of changes to prepare the deprecation of Python 2 in favour of Python 3 [[1]](https://fedoraproject.org/wiki/Category:ChangeAcceptedF30). As part of this transition process, ambiguous shebangs in Python scripts are no longer allowed [[2]](https://fedoraproject.org/wiki/Changes/Make_ambiguous_python_shebangs_error). Packagers can not rely anymore on the presence of `/usr/bin/python` (which was equivalent to `/usr/bin/python2` up to Fedora 29) and need to explicitly select the Python interpreter. 

The KiCad copr build for rawhide currently fails with the following error message:
```
+ /usr/lib/rpm/redhat/brp-mangle-shebangs
*** WARNING: ./usr/share/kicad/scripting/plugins/FPC_wizard.py is executable but has empty or no shebang, removing executable bit
*** WARNING: ./usr/share/kicad/scripting/plugins/FootprintWizardBase.py is executable but has empty or no shebang, removing executable bit
*** WARNING: ./usr/share/kicad/scripting/plugins/PadArray.py is executable but has empty or no shebang, removing executable bit
*** WARNING: ./usr/share/kicad/scripting/plugins/bga_wizard.py is executable but has empty or no shebang, removing executable bit
*** WARNING: ./usr/share/kicad/scripting/plugins/circular_pad_array_wizard.py is executable but has empty or no shebang, removing executable bit
*** WARNING: ./usr/share/kicad/scripting/plugins/microMatch_connectors.py is executable but has empty or no shebang, removing executable bit
*** WARNING: ./usr/share/kicad/scripting/plugins/qfn_wizard.py is executable but has empty or no shebang, removing executable bit
*** WARNING: ./usr/share/kicad/scripting/plugins/qfp_wizard.py is executable but has empty or no shebang, removing executable bit
*** WARNING: ./usr/share/kicad/scripting/plugins/qrcode.py is executable but has empty or no shebang, removing executable bit
*** WARNING: ./usr/share/kicad/scripting/plugins/qrcode_footprint_wizard.py is executable but has empty or no shebang, removing executable bit
*** WARNING: ./usr/share/kicad/scripting/plugins/sdip_wizard.py is executable but has empty or no shebang, removing executable bit
*** ERROR: ambiguous python shebang in /usr/share/kicad/scripting/plugins/touch_slider_wizard.py: #!/usr/bin/python. Change it to python3 (or python2) explicitly.
*** WARNING: ./usr/share/kicad/scripting/plugins/uss39_barcode.py is executable but has empty or no shebang, removing executable bit
*** WARNING: ./usr/share/kicad/scripting/plugins/zip_wizard.py is executable but has empty or no shebang, removing executable bit
error: Bad exit status from /var/tmp/rpm-tmp.vSC1uf (%install)
```

This patch replaces the ambiguous shebang in touch_slider_wizard.py to fix the packaging error. It does not handle the warnings about Python scripts without a shebang that have their executable flag set. This should be considered a temporary fix until the upstream developers have decided about the future of the Python scripting support. Someone with more knowledge about Python than I have should check all of the scripts and decide whether shebangs need to be added to the upstream source files or the executable flags needs to be removed as part of the packaging process.

If @pointhi's proposal to add Python 3 support to KiCad [[3]](https://github.com/pointhi/kicad-source-mirror/tree/wx-python) is accepted, then also the shebangs will need to be modified (or dynamically generated) as part of the build process to match the selected version.

@stevefalco: I have modified your build script to simply copy all *.patch files to the SOURCES directory. Please let me know if this approach is acceptable or if there is a more elegant way to handle patches.

[1] https://fedoraproject.org/wiki/Category:ChangeAcceptedF30
[2] https://fedoraproject.org/wiki/Changes/Make_ambiguous_python_shebangs_error
[3] https://github.com/pointhi/kicad-source-mirror/tree/wx-python