### PR TITLE
Fix Fedora 29 build - missing dependency.

### DIFF
--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -39,6 +39,7 @@ BuildRequires:  libcurl-devel
 BuildRequires:  OCE-devel
 BuildRequires:  openssl-devel
 BuildRequires:  python2-devel
+BuildRequires:  mesa-libEGL-devel
 
 # Documentation
 BuildRequires:  asciidoc


### PR DESCRIPTION
Fedora 29 now needs a BuildRequires for mesa-libEGL-devel.