### PR TITLE
Enable support for simulation based on ngspice

### DIFF
--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -36,6 +36,9 @@ BuildRequires:  compat-wxGTK3-gtk2-devel
 BuildRequires:  glew-devel
 BuildRequires:  glm-devel
 BuildRequires:  libcurl-devel
+%if 0%{?fedora} > 27
+BuildRequires:  libngspice-devel
+%endif
 BuildRequires:  OCE-devel
 BuildRequires:  openssl-devel
 BuildRequires:  python2-devel
@@ -83,8 +86,10 @@ Documentation for KiCad.
 # compat-wxGTK3-gtk2-devel is now merged with wxGTK3-devel and uses a single wx-config
 %if 0%{?fedora} > 27
 %global wx_config wx-config
+%global kicad_spice ON
 %else
 %global wx_config wx-config-3.0-gtk2
+%global kicad_spice OFF
 %endif
 
 # KiCad application
@@ -98,7 +103,7 @@ Documentation for KiCad.
     -DKICAD_USE_OCE=ON \
     -DKICAD_INSTALL_DEMOS=ON \
     -DBUILD_GITHUB_PLUGIN=ON \
-    -DKICAD_SPICE=OFF \
+    -DKICAD_SPICE=%{kicad_spice} \
     @VERSION_EXTRA@ \
     -DCMAKE_BUILD_TYPE=@BUILD_TYPE@ \
     -DwxWidgets_CONFIG_EXECUTABLE=%{_bindir}/%{wx_config} \


### PR DESCRIPTION
As requested by @nickoe [[1]](https://forum.kicad.info/t/simulation-not-included-on-fedora-29/14343/5), I have taken a look at the newly released ngspice 30 packages (which ship the shared library required by KiCad [[2]](https://bugzilla.redhat.com/show_bug.cgi?id=1440904)) and modified the nightly SPEC file to enable simulation.

The result is not very pretty, because Fedora 27 is EOL and does not get updated anymore. Copr, on the other hand, has not yet dropped F27, which means we need to handle this as a special case for now. Alternatively, we could also manually disable nightly builds for F27, but that might unnecessarily affect some of our users with an older installation.

This change is not ready for merge yet. First of all, it needs more testing (I only tested on F29). Secondly, we have to wait for the new ngspice packages to find their way into the stable updates repository of both F28 [[3]](https://bodhi.fedoraproject.org/updates/FEDORA-2019-513a22cc85) and F29 [[4]](https://bodhi.fedoraproject.org/updates/FEDORA-2019-cfba6d272c).

Please let me know what you think.

[1] https://forum.kicad.info/t/simulation-not-included-on-fedora-29/14343/5
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1440904
[3] https://bodhi.fedoraproject.org/updates/FEDORA-2019-513a22cc85
[4] https://bodhi.fedoraproject.org/updates/FEDORA-2019-cfba6d272c