### PR TITLE
Add the ability to build from any commit

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -14,7 +14,7 @@ get_one () {
 		cd "build/${WHAT}"
 		git fetch origin
 		git reset --hard origin/master
-		git checkout "${TAG}"
+		git checkout "${TAG}" || git checkout HEAD
 		)
 	else 
 		(
@@ -53,6 +53,8 @@ make_tar () {
 	echo "Creating ${WHAT}-${FULL_VERSION}.tar.gz from ${TAG}..."
 	set -x
 	git archive --format=tar.gz --prefix="${WHAT}-${FULL_VERSION}/" "${TAG}" > \
+		"../rpmbuild/SOURCES/${WHAT}-${FULL_VERSION}.tar.gz" ||
+	git archive --format=tar.gz --prefix="${WHAT}-${FULL_VERSION}/" HEAD > \
 		"../rpmbuild/SOURCES/${WHAT}-${FULL_VERSION}.tar.gz"
 	)
 }

--- a/builder.sh
+++ b/builder.sh
@@ -78,7 +78,7 @@ show_help () {
 	echo "a build at a later time." >&2
 	echo "" >&2
 	echo "example: $0 -c your_copr_id/kicad" >&2
-	echo "example: $0 -m fedora-27-x86_64" >&2
+	echo "example: $0 -m fedora-30-x86_64" >&2
 	set -x
 }
 


### PR DESCRIPTION
I'd like to be able to build from any selected commit on the 5.1 branch.  In that case, a KiCad source repo SHA can be specified in place of a tag, but the other repos, like i18n, doc, etc won't have that SHA, and the build will fail.

This patch adds a fallback to build from the HEAD of any repo that is missing a specified SHA.

For example, I can do: 

` ./builder.sh -t e99a2181ffe83732c68e100f3a22441f42404c55 -m fedora-30-x86_64`

This will use the e99a218... commit from the source repo, along with the HEADs of all other repos.

Also, update the help to mention f30 rather than f27.
