### PR TITLE
Python cache fix

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -21,7 +21,7 @@ get_one () {
 		cd build
 		git clone "${WHERE}/${WHAT}"
 		cd "${WHAT}"
-		git checkout "${TAG}"
+		git checkout "${TAG}" || git checkout HEAD
 		)
 	fi
 }

--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -201,7 +201,8 @@ appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/appdata/*.appdata
 %{_bindir}/*
 %{_libdir}/%{name}/
 %{_libdir}/libkicad_3dsg.so*
-%{python3_sitelib}/*
+%{python3_sitelib}/*pcbnew*
+%{python3_sitelib}/__pycache__/*
 %{_datadir}/%{name}/
 %exclude %{_datadir}/%{name}/modules/packages3d/*
 %{_datadir}/appdata/*.xml


### PR DESCRIPTION
https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/ require a small change to remove the __pycache__ from our rpm files.  This avoids a directory conflict.

Also found another place where it could be helpful to checkout the HEAD if a tag is not found.