### PR TITLE
Enable PPC64LE target

### DIFF
--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -21,7 +21,7 @@ Source5:        %{name}-packages3D-%{full_version}.tar.gz
 Source6:        %{name}-doc-%{full_version}.tar.gz
 
 # https://bugs.launchpad.net/kicad/+bug/1755752
-ExclusiveArch: %{ix86} x86_64 %{arm} aarch64
+ExclusiveArch: %{ix86} x86_64 %{arm} aarch64 ppc64le
 
 BuildRequires:  cmake
 BuildRequires:  desktop-file-utils


### PR DESCRIPTION
We should enable the ppc64le target, so as to more quickly discover future compile regressions.

I've built and tested on a local ppc64le VM.  I was also able to build on Copr, both for Fedora 30 and Rawhide.

If this patch is accepted, then the official @Kicad Copr should also be modified to include ppc64le as a build target.