### PR TITLE
Use OCC for F32 and up

### DIFF
--- a/kicad.spec.template
+++ b/kicad.spec.template
@@ -36,11 +36,19 @@ BuildRequires:  glew-devel
 BuildRequires:  glm-devel
 BuildRequires:  libcurl-devel
 BuildRequires:  libngspice-devel
-BuildRequires:  OCE-devel
 BuildRequires:  openssl-devel
 BuildRequires:  python3-wxpython4
 BuildRequires:  python3-devel
 BuildRequires:  wxGTK3-devel
+
+# For F32 and up, use opencascade rather than the community edition.
+%if 0%{?fedora} > 31
+%define CASCADE KICAD_USE_OCC
+BuildRequires:  opencascade-devel
+%else
+%define CASCADE KICAD_USE_OCE
+BuildRequires:  OCE-devel
+%endif
 
 # Documentation
 BuildRequires:  asciidoc
@@ -93,7 +101,7 @@ Documentation for KiCad.
     -DKICAD_SCRIPTING_WXPYTHON_PHOENIX=ON \
     -DKICAD_SCRIPTING_PYTHON3=ON \
     -DKICAD_SCRIPTING_ACTION_MENU=ON \
-    -DKICAD_USE_OCE=ON \
+    -D%{CASCADE}=ON \
     -DKICAD_INSTALL_DEMOS=ON \
     -DBUILD_GITHUB_PLUGIN=ON \
     -DKICAD_SPICE=ON \


### PR DESCRIPTION
Fedora rawhide (and hence F32) will have the mainline opencascade package available.  Thus, we can stop using the community edition.