### PR TITLE
Launchpad git to be deprecated.

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -128,7 +128,7 @@ rm -fr build/rpmbuild
 mkdir -p build/rpmbuild/{SPECS,SOURCES}
 
 # Get/update the source repos.
-get_one "kicad"			"https://git.launchpad.net"	"${TAG}"
+get_one "kicad"			"https://gitlab.com/kicad/code"	"${TAG}"
 get_one "kicad-i18n"		"https://github.com/KiCad"	"${TAG}"
 get_one "kicad-doc"		"https://github.com/KiCad"	"${TAG}"
 get_one "kicad-templates"	"https://github.com/KiCad"	"${TAG}"


### PR DESCRIPTION
GitLab mirror is active now and will transition to primary status soon.

@nickoe  - @sethhillbrand has requested a pull here:

https://github.com/KiCad/fedora-packaging/pull/37

But his doesn't work, as I've described in his pull request.  So here is my version.  I believe it will work properly for the nightlies.

I recommend dropping his pull request and applying mine instead.  Please let me know if you have any problems with it.

Steve